### PR TITLE
Fix #24 DirectoryServiceEntry now serializable

### DIFF
--- a/src/groovy/grails/plugins/directoryservice/DirectoryServiceEntry.groovy
+++ b/src/groovy/grails/plugins/directoryservice/DirectoryServiceEntry.groovy
@@ -29,7 +29,8 @@ import com.unboundid.ldap.sdk.SearchResultEntry
  *
  * @author Lucas Rockwell
  */
-class DirectoryServiceEntry {
+class DirectoryServiceEntry implements Serializable {
+    private static final long serialVersionUID = -648257487032312756L;
 
     /**
      * The original searchResultEntry.

--- a/src/groovy/grails/plugins/directoryservice/DirectoryServiceEntry.groovy
+++ b/src/groovy/grails/plugins/directoryservice/DirectoryServiceEntry.groovy
@@ -75,7 +75,7 @@ class DirectoryServiceEntry implements Serializable {
      * implements the Spring Errors interface, so the error handling will
      * change.
      */
-    def errors = [:]
+    Map errors = [:]
 
     /**
      * Holds the actual directory modifications.


### PR DESCRIPTION
I have verified that all entries in the properties are all serializable. The errors property is now a map to ensure this.
