### PR TITLE
Expose in-memory createSnapshot and restoreSnapshot methods

### DIFF
--- a/src/groovy/grails/plugins/directoryservice/listener/InMemoryDirectoryServer.groovy
+++ b/src/groovy/grails/plugins/directoryservice/listener/InMemoryDirectoryServer.groovy
@@ -19,6 +19,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer as InMemServer
+import com.unboundid.ldap.listener.InMemoryDirectoryServerSnapshot
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig
 import com.unboundid.ldap.listener.InMemoryListenerConfig
 import com.unboundid.ldap.sdk.Entry
@@ -280,5 +281,13 @@ class InMemoryDirectoryServer {
         finally {
             ldifReader.close()
         }
+    }
+
+    InMemoryDirectoryServerSnapshot createSnapshot() {
+        return server.createSnapshot()
+    }
+
+    def restoreSnapshot(InMemoryDirectoryServerSnapshot snapshot) {
+        server.restoreSnapshot(snapshot)
     }
 }

--- a/test/integration/grails/plugins/directoryservice/DirectoryServiceTests.groovy
+++ b/test/integration/grails/plugins/directoryservice/DirectoryServiceTests.groovy
@@ -448,4 +448,21 @@ class DirectoryServiceTests extends GroovyTestCase {
          assertNull person
      }
 
+     /**
+      * Test snapshotting
+      */
+     void testSnapshot() {
+         def snapshot = inMemServer.createSnapshot()
+         def person = directoryService.getPerson('1')
+         assertNotNull person
+         
+         directoryService.connection(peopleBaseDn)?.delete(person.dn)  
+         person = directoryService.getPerson('1')
+         assertNull person
+
+         inMemServer.restoreSnapshot(snapshot)
+         person = directoryService.getPerson('1')
+         assertNotNull person
+    }
+
 }


### PR DESCRIPTION
These methods are really useful for testing since they let you start each test with a known clean state of the directory.
